### PR TITLE
nodejs14 now GA

### DIFF
--- a/appengine_templates/app.yaml.tpl
+++ b/appengine_templates/app.yaml.tpl
@@ -1,5 +1,5 @@
 service: bum-ui
-runtime: nodejs12
+runtime: nodejs14
 
 vpc_access_connector:
   name: projects/_PROJECT_ID/locations/europe-west2/connectors/vpcconnect


### PR DESCRIPTION
Runtime is now GA so bumping app engine runtime env.